### PR TITLE
Add custom colours selection in 'APSC Options' tab

### DIFF
--- a/apsc-site-settings.php
+++ b/apsc-site-settings.php
@@ -11,7 +11,7 @@
  * Plugin Name:       APSC Site Settings
  * Plugin URI:        https://apsc.ubc.ca
  * Description:       Additional Site Settings and Options for APSC Websites
- * Version:           1.0.0
+ * Version:           1.1.0
  * Requires at least: 5.2
  * Requires PHP:      7.2
  * Author:            Rich Tape

--- a/inc/css/apsc-site-settings-admin.css
+++ b/inc/css/apsc-site-settings-admin.css
@@ -1,0 +1,17 @@
+#apsc-design-system-custom-colours-box .wp-picker-container {
+	display:block;
+	position: relative;
+	clear:both;
+	margin-top: 0.5rem;
+}
+
+#apsc-colours-managed {
+	height: 32px;
+    position: absolute;
+    z-index: 10000;
+    left: -25px;
+    width: 280px;
+    background: rgba(255, 255, 255, 0.95);
+    line-height: 2;
+    font-weight: 600;
+}

--- a/inc/js/apsc-site-settings-admin.js
+++ b/inc/js/apsc-site-settings-admin.js
@@ -1,0 +1,123 @@
+jQuery(document).ready(function() {
+	
+	var clf_update_custom_colour1_checkbox = true;
+	var clf_update_custom_colour2_checkbox = true;
+	var clf_update_custom_colour3_checkbox = true;
+	
+	// Initialize the colour pickers
+    jQuery("#apsc-custom-unit-colour-primary").wpColorPicker({
+            change: function (event, ui) {
+            	// we need to select the radio button
+            	if( clf_update_custom_colour1_checkbox ) {
+            			jQuery("#ubc-collab-theme-options-apsc-custom-unit-colours").prop('checked', true );
+            		}
+            	 clf_update_custom_colour1_checkbox = true;
+            }
+        });
+	
+    jQuery("#apsc-custom-unit-colour-secondary").wpColorPicker({
+            change: function (event, ui) {
+            	// we need to select the radio button
+            	if( clf_update_custom_colour2_checkbox ) {
+            			jQuery("#ubc-collab-theme-options-apsc-custom-unit-colours").prop('checked', true );
+            		}
+            	 clf_update_custom_colour2_checkbox = true;
+            }
+        });
+	
+    jQuery("#apsc-custom-unit-colour-tertiary").wpColorPicker({
+            change: function (event, ui) {
+            	// we need to select the radio button
+            	if( clf_update_custom_colour3_checkbox ) {
+            			jQuery("#ubc-collab-theme-options-apsc-custom-unit-colours").prop('checked', true );
+            		}
+            	 clf_update_custom_colour3_checkbox = true;
+            }
+        });
+
+
+	// Listen for changes on the unit select, update the colour palettes based on the selected unit if they are not marked as customised
+	jQuery("select[name='ubc-collab-theme-options[apsc-unit]']").on("change", function() {
+		var isCustomChecked = jQuery("#ubc-collab-theme-options-apsc-custom-unit-colours").is(":checked");
+		if (!isCustomChecked) {
+			updateColourPalettes();
+		}
+	});
+
+	// Listen for changes on the standard CLF colours, update the custom colour palettes accordingly
+	jQuery("#colour-ubc-blue").on("change", function() {
+		clf_update_colour();
+	});
+
+	// Listen for changes on the standard CLF colours, update the custom colour palettes accordingly
+	jQuery("#colour-ubc-grey").on("change", function() {
+		clf_update_colour();
+	});
+	
+	// Standard CLF Colour Options, activates custom colours and set the custom primary colour to matching CLF colour
+    function clf_update_colour () {
+    	if ( jQuery("#ubc-grey input").is(':checked') ) {
+			jQuery("#ubc-collab-theme-options-apsc-custom-unit-colours").prop('checked', true );
+			jQuery("#apsc-custom-unit-colour-primary").wpColorPicker("color", '#2F5D7C');
+			toggleCustomColourPickers();
+    	}
+    	else if (jQuery("#ubc-blue input").is(':checked')) {
+			jQuery("#ubc-collab-theme-options-apsc-custom-unit-colours").prop('checked', true );
+			jQuery("#apsc-custom-unit-colour-primary").wpColorPicker("color", '#002145');
+			toggleCustomColourPickers();
+    	}
+    }
+
+	// Resets to selected unit's default colours 
+	jQuery("#apsc-custom-unit-colour-reset").on("click", function(event) {
+		event.preventDefault(); // Prevent the default link behavior
+		updateColourPalettes(); // Call the function to update colours
+	});
+
+	
+	// Function to toggle the visibility of the custom colour pickers
+	function toggleCustomColourPickers() {
+		var isChecked = jQuery("#ubc-collab-theme-options-apsc-custom-unit-colours").is(":checked");
+		jQuery("#apsc-custom-unit-colour-palettes").toggle(isChecked);
+	}
+
+	// Function to update the colour palettes based on the selected unit
+	// This function makes an AJAX call to get the colours for the selected unit
+	// and updates the colour pickers accordingly.
+	function updateColourPalettes() {
+		var selectedUnit = jQuery("select[name='ubc-collab-theme-options[apsc-unit]']").val();
+
+		jQuery.ajax({
+			url: ajax_callback_get_unit_colours_obj.ajax_url, // Localized in PHP
+			type: "POST",
+			dataType: "json",
+			data: {
+				action: "ajax_callback_get_unit_colours",
+				unit: selectedUnit,
+				nonce: ajax_callback_get_unit_colours_obj.nonce // Nonce for security
+			},
+			success: function(response) {
+				if (response.success && response.data) {
+					// Update the colour pickers
+					clf_update_custom_colour1_checkbox = false;
+					clf_update_custom_colour2_checkbox = false;
+					clf_update_custom_colour3_checkbox = false;
+					jQuery("#clf-unit-colour").wpColorPicker("color", response.data[0].color); // set primary colour on UBC CLF tab colour picker
+					jQuery("#apsc-custom-unit-colour-primary").wpColorPicker("color", response.data[0].color);
+					jQuery("#apsc-custom-unit-colour-secondary").wpColorPicker("color", response.data[1].color);
+					jQuery("#apsc-custom-unit-colour-tertiary").wpColorPicker("color", response.data[2].color);
+				}
+			}
+		});
+	}
+
+	jQuery("#clf-default-colour").prop('disabled', true).addClass("transparent");
+	// Wait until .wp-picker-container exists before adding the message
+	var intervalId = setInterval(function() {
+		var $container = jQuery("#clf-unit-colour-box .wp-picker-container");
+		if ($container.length) {
+			$container.prepend('<div id="apsc-colours-managed">Custom colours managed by <a href="#apsc-theme-options" id="apsc-theme-options-link" onclick="event.preventDefault(); jQuery(\'a[href=\\\'#apsc-theme-options\\\']\').trigger(\'click\');">APSC Options</a></div>');
+			clearInterval(intervalId);
+		}
+	}, 100);
+});

--- a/readme.md
+++ b/readme.md
@@ -37,3 +37,20 @@ A text entry field which will be used as the URL to load the APSC Design System.
 Default Value: https://apsc-design-system.netlify.app/design-system.min.css
 
 see `get_design_system_url()` in APSC Blocks plugin for how this logic is detailed.
+
+## Define custom colours
+
+A checkbox and set of colour pickers for primary, secondary, tertiary colours. 
+
+The colour pickers update via an AJAX call when the APSC Unit Selection is updated, or when standard CLF colours are selected (UBC CLF tab). 
+
+When the checkbox is selected, the values from the colour pickers are preserved and require manual input and saving for changes to apply.
+
+The values for the colours are accessible in the CSS with these CSS variables:
+	`--wp--preset--color--apsc-unit-primary`
+	`--wp--preset--color--apsc-unit-secondary`
+	`--wp--preset--color--apsc-unit-tertiary`
+
+Default Values:
+Set custom colours: Unchecked (i.e. footer not hidden)
+Colour pickers: Currently selected unit colour palette


### PR DESCRIPTION
Adds a new section in the 'APSC Options' tab.
Define a new checkbox to set custom colours.
Define three new colour pickers for primary, secondary and tertiary unit colours. Related CSS and JS.
Update readme.